### PR TITLE
Fixed missing bracket in deepstream_paraller_infer_app.cpp

### DIFF
--- a/deepstream_parallel_inference_app/tritonclient/sample/apps/deepstream-parallel-infer/deepstream_parallel_infer_app.cpp
+++ b/deepstream_parallel_inference_app/tritonclient/sample/apps/deepstream-parallel-infer/deepstream_parallel_infer_app.cpp
@@ -1578,6 +1578,7 @@ int main(int argc, char *argv[])
   /* Wait till pipeline encounters an error or EOS */
   g_print("Running...\n");
   g_main_loop_run(main_loop);
+  }
 
 done:
 


### PR DESCRIPTION
Added missing bracket for if clause which caused compilation errors like so:

```
deepstream_parallel_infer_app.cpp:1690:3: error: jump to label 'done'
 1690 |   done:
      |   ^~~~
deepstream_parallel_infer_app.cpp:1539:10: note:   from here
 1539 |     goto done;
      |          ^~~~
deepstream_parallel_infer_app.cpp:1613:18: note:   crosses initialization of 'DemoPerfCtx* perf_ctx'
 1613 |     DemoPerfCtx *perf_ctx = (DemoPerfCtx *)g_malloc0(sizeof(DemoPerfCtx));
      |                  ^~~~~~~~
deepstream_parallel_infer_app.cpp:1612:27: note:   crosses initialization of 'NvDsAppPerfStructInt* str'
 1612 |     NvDsAppPerfStructInt *str = (NvDsAppPerfStructInt *)g_malloc0(sizeof(NvDsAppPerfStructInt));
      |                           ^~~
deepstream_parallel_infer_app.cpp:1729:25: error: expected '}' at end of input
 1729 |     return return_value;
      |                         ^
deepstream_parallel_infer_app.cpp:1575:3: note: to match this '{'
 1575 |   {
      |   ^
deepstream_parallel_infer_app.cpp:1729:25: error: expected '}' at end of input
 1729 |     return return_value;
      |                         ^
deepstream_parallel_infer_app.cpp:1406:1: note: to match this '{'
 1406 | {
```